### PR TITLE
Fixed the isSynthetic() function in AccessModifierQuery.java to return the correct evaluation

### DIFF
--- a/src/main/java/org/mutabilitydetector/checkers/AccessModifierQuery.java
+++ b/src/main/java/org/mutabilitydetector/checkers/AccessModifierQuery.java
@@ -80,7 +80,7 @@ public class AccessModifierQuery {
     }
     
     public boolean isSynthetic() {
-        return !is(ACC_SYNTHETIC);
+        return is(ACC_SYNTHETIC);
     }
     
     public boolean isNotSynthetic() {


### PR DESCRIPTION
isSynthetic() previously returned return !is(ACC_SYNTHETIC) and has been fixed to return is(ACC_SYNTHETIC).
