### PR TITLE
Hardcode that java.net.URI is immutable.

### DIFF
--- a/src/main/java/org/mutabilitydetector/config/JdkConfiguration.java
+++ b/src/main/java/org/mutabilitydetector/config/JdkConfiguration.java
@@ -24,6 +24,7 @@ import org.mutabilitydetector.ConfigurationBuilder;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.net.URI;
 
 /**
  * Non-exhaustive list of immutable classes from the standard JDK.
@@ -56,6 +57,7 @@ public class JdkConfiguration extends ConfigurationBuilder {
         hardcodeAsDefinitelyImmutable(BigDecimal.class);
         hardcodeAsDefinitelyImmutable(BigInteger.class);
         hardcodeAsDefinitelyImmutable(Class.class);
+        hardcodeAsDefinitelyImmutable(URI.class);
 
         hardcodeAsImmutableContainerType("java.util.Optional");
     }

--- a/src/test/java/org/mutabilitydetector/WellKnownJavaTypesTest.java
+++ b/src/test/java/org/mutabilitydetector/WellKnownJavaTypesTest.java
@@ -33,6 +33,7 @@ import static org.mutabilitydetector.unittesting.MutabilityMatchers.areNotImmuta
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.net.URI;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Date;
@@ -113,6 +114,11 @@ public class WellKnownJavaTypesTest {
     @Test
     public void Class() {
         assertInstancesOf(Class.class, areNotImmutable());
+    }
+
+    @Test
+    public void URI() {
+        assertInstancesOf(URI.class, areNotImmutable());
     }
 
     @Test


### PR DESCRIPTION
Quote for the [URI JavaDoc](https://docs.oracle.com/javase/8/docs/api/java/net/URI.html):
> "Instances of this class are immutable."

Prior to the change, the following class is deemed mutable:

    static final class TestClass {
        private final URI uri; 

        TestClass(final URI uri) {
            this.uri = uri; 
        }
    }
