### PR TITLE
#51 - Error message improved for unwrapped Collections

### DIFF
--- a/src/main/java/org/mutabilitydetector/checkers/MutableTypeToFieldChecker.java
+++ b/src/main/java/org/mutabilitydetector/checkers/MutableTypeToFieldChecker.java
@@ -240,7 +240,7 @@ public final class MutableTypeToFieldChecker extends AsmMutabilityChecker {
         }
 
         private void setUnsafeWrappingResult(FieldLocation fieldLocation) {
-            setResult("Attempts to wrap mutable collection type using a non-whitelisted unmodifiable wrapper method.",
+            setResult("Field is not a wrapped collection type.",
                       fieldLocation, ABSTRACT_COLLECTION_TYPE_TO_FIELD);
         }
 

--- a/src/test/java/org/mutabilitydetector/benchmarks/mutabletofield/MutableTypeToFieldCheckerTest.java
+++ b/src/test/java/org/mutabilitydetector/benchmarks/mutabletofield/MutableTypeToFieldCheckerTest.java
@@ -259,7 +259,7 @@ public class MutableTypeToFieldCheckerTest {
         MutableReasonDetail reasonDetail = result.reasons.iterator().next();
 
         assertEquals(ABSTRACT_COLLECTION_TYPE_TO_FIELD, reasonDetail.reason());
-        assertThat(reasonDetail.message(), is("Attempts to wrap mutable collection type using a non-whitelisted unmodifiable wrapper method."));
+        assertThat(reasonDetail.message(), is("Field is not a wrapped collection type."));
     }
 
     @Test


### PR DESCRIPTION
Hi,

First time commit: resolving issue #51 by changing the displayed error message to "Field is not a wrapped collection type."

Thanks.