### PR TITLE
Add test to check exact hint message

### DIFF
--- a/src/test/java/org/mutabilitydetector/benchmarks/mutabletofield/MutableTypeToFieldCheckerTest.java
+++ b/src/test/java/org/mutabilitydetector/benchmarks/mutabletofield/MutableTypeToFieldCheckerTest.java
@@ -247,7 +247,7 @@ public class MutableTypeToFieldCheckerTest {
         MutableReasonDetail reasonDetail = result.reasons.iterator().next();
 
         assertEquals(ABSTRACT_COLLECTION_TYPE_TO_FIELD, reasonDetail.reason());
-        assertThat(reasonDetail.message(), CoreMatchers.is("Attempts to wrap mutable collection type without safely performing a copy first. You can use this expression: Collections.unmodifiableList(new ArrayList<ImmutableExample>(unmodifiable))"));
+        assertThat(reasonDetail.message(), is("Attempts to wrap mutable collection type without safely performing a copy first. You can use this expression: Collections.unmodifiableList(new ArrayList<ImmutableExample>(unmodifiable))"));
     }
 
     @Test

--- a/src/test/java/org/mutabilitydetector/benchmarks/mutabletofield/MutableTypeToFieldCheckerTest.java
+++ b/src/test/java/org/mutabilitydetector/benchmarks/mutabletofield/MutableTypeToFieldCheckerTest.java
@@ -22,6 +22,7 @@ package org.mutabilitydetector.benchmarks.mutabletofield;
 
 
 import com.google.common.collect.ImmutableSet;
+import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
@@ -234,6 +235,19 @@ public class MutableTypeToFieldCheckerTest {
 
         assertEquals(ABSTRACT_COLLECTION_TYPE_TO_FIELD, reasonDetail.reason());
         assertThat(reasonDetail.message(), startsWith("Attempts to wrap mutable collection type without safely performing a copy first."));
+    }
+
+    @Test
+    public void providesHintIfWrappedInUnmodifiableCollectionTypeButIsNotCopiedFirst() throws Exception {
+        checkerWithRealSession = checkerWithRealAnalysisSession();
+
+        result = runChecker(checkerWithRealSession, WrapWithUnmodifiableListWithoutCopyingFirst.class);
+
+        assertThat(result, areNotImmutable());
+        MutableReasonDetail reasonDetail = result.reasons.iterator().next();
+
+        assertEquals(ABSTRACT_COLLECTION_TYPE_TO_FIELD, reasonDetail.reason());
+        assertThat(reasonDetail.message(), CoreMatchers.is("Attempts to wrap mutable collection type without safely performing a copy first. You can use this expression: Collections.unmodifiableList(new ArrayList<ImmutableExample>(unmodifiable))"));
     }
 
     @Test


### PR DESCRIPTION
> I would like to see MutableTypeToFieldCheckerTest be extended to assert on the exact message that will be received by the user.

Hope I understood you correctly and the test below is exactly what you meant.
Please review.
Thank you :smile_cat: 