### PR TITLE
squid:S1488 - Local Variables should not be declared and then immedia…

### DIFF
--- a/src/main/java/org/mutabilitydetector/checkers/FieldAssignmentVisitor.java
+++ b/src/main/java/org/mutabilitydetector/checkers/FieldAssignmentVisitor.java
@@ -101,7 +101,6 @@ public abstract class FieldAssignmentVisitor extends MethodNode {
 
     protected BasicValue getStackValue(Frame<BasicValue> assignmentFrame) {
         int stackSlot = assignmentFrame.getStackSize() - 1;
-        BasicValue stackValue = assignmentFrame.getStack(stackSlot);
-        return stackValue;
+        return assignmentFrame.getStack(stackSlot);
     }
 }

--- a/src/main/java/org/mutabilitydetector/checkers/OldSetterMethodChecker.java
+++ b/src/main/java/org/mutabilitydetector/checkers/OldSetterMethodChecker.java
@@ -123,9 +123,7 @@ public final class OldSetterMethodChecker extends AsmMutabilityChecker {
              * field is a parameter. But if the type is not included in the parameter list, we can guess it's not
              * (though it still may be).
              */
-            boolean reassignmentIsOnATypeIncludedInParameters = this.desc.contains(fieldInsnNode.owner);
-
-            return reassignmentIsOnATypeIncludedInParameters;
+            return this.desc.contains(fieldInsnNode.owner);
         }
 
         private boolean reassignedIsThisType(String ownerOfReassignedField) {

--- a/src/main/java/org/mutabilitydetector/checkers/settermethod/ControlFlowBlock.java
+++ b/src/main/java/org/mutabilitydetector/checkers/settermethod/ControlFlowBlock.java
@@ -398,8 +398,7 @@ final class ControlFlowBlock implements Comparable<ControlFlowBlock> {
     }
 
     public int getIndexWithinBlock(final int indexWithinMethod) {
-        final int result = indexWithinMethod - rangeOfBlockInstructions.lowerBoundary;
-        return result;
+        return indexWithinMethod - rangeOfBlockInstructions.lowerBoundary;
     }
 
     public Set<ControlFlowBlock> getPredecessors() {

--- a/src/main/java/org/mutabilitydetector/checkers/settermethod/InitialValueFinder.java
+++ b/src/main/java/org/mutabilitydetector/checkers/settermethod/InitialValueFinder.java
@@ -223,8 +223,7 @@ final class InitialValueFinder implements Finder<Set<UnknownTypeValue>> {
         final AssignmentInsn effectiveAssignmentInsn = f.find();
         final int indexOfAssignmentInstruction = effectiveAssignmentInsn.getIndexWithinMethod();
         final InsnList instructions = constructor.instructions;
-        final AbstractInsnNode result = instructions.get(indexOfAssignmentInstruction - 1);
-        return result;
+        return instructions.get(indexOfAssignmentInstruction - 1);
     }
 
     private void addSupposedInitialValueFor(final AbstractInsnNode variableValueSetupInsn) {

--- a/src/main/java/org/mutabilitydetector/cli/RunMutabilityDetector.java
+++ b/src/main/java/org/mutabilitydetector/cli/RunMutabilityDetector.java
@@ -146,8 +146,7 @@ public final class RunMutabilityDetector implements Runnable, Callable<String> {
 
     private static BatchAnalysisOptions createOptionsFromArgs(String[] args) {
         try {
-            BatchAnalysisOptions options = new CommandLineOptions(System.err, args);
-            return options;
+            return new CommandLineOptions(System.err, args);
         } catch (Throwable e) {
             System.out.println("Exiting...");
             System.exit(1);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1488 - Local Variables should not be declared and then immediately returned or thrown

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1488

Please let me know if you have any questions.

M-Ezzat