### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/org/mutabilitydetector/Configurations.java
+++ b/src/main/java/org/mutabilitydetector/Configurations.java
@@ -25,7 +25,7 @@ import org.mutabilitydetector.config.GuavaConfiguration;
 import org.mutabilitydetector.config.JdkConfiguration;
 import org.mutabilitydetector.unittesting.MutabilityAssert;
 
-public class Configurations {
+public final class Configurations {
 
 
     /**
@@ -66,5 +66,9 @@ public class Configurations {
             merge(GUAVA_CONFIGURATION);
         }
     }.build();
+
+    private Configurations() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
 }

--- a/src/main/java/org/mutabilitydetector/checkers/settermethod/NullAssignmentInsn.java
+++ b/src/main/java/org/mutabilitydetector/checkers/settermethod/NullAssignmentInsn.java
@@ -32,6 +32,11 @@ public final class NullAssignmentInsn implements AssignmentInsn {
 
     private static final class InstanceHolder {
         private static final NullAssignmentInsn INSTANCE = new NullAssignmentInsn();
+
+        private InstanceHolder() throws InstantiationException {
+            throw new InstantiationException("This class is not created for instantiation");
+        }
+
     }
 
     private NullAssignmentInsn() {

--- a/src/main/java/org/mutabilitydetector/checkers/settermethod/NullJumpInsn.java
+++ b/src/main/java/org/mutabilitydetector/checkers/settermethod/NullJumpInsn.java
@@ -33,6 +33,10 @@ final class NullJumpInsn implements JumpInsn {
 
     private static final class InstanceHolder {
         private static final JumpInsn INSTANCE = new NullJumpInsn();
+
+        private InstanceHolder() throws InstantiationException {
+            throw new InstantiationException("This class is not created for instantiation");
+        }
     }
 
     private static final JumpInsnNode EMPTY_JUMP_INSN_NODE = new JumpInsnNode(Opcodes.NOP, null);

--- a/src/main/java/org/mutabilitydetector/classpath/ClassPathScanner.java
+++ b/src/main/java/org/mutabilitydetector/classpath/ClassPathScanner.java
@@ -25,7 +25,11 @@ import org.reflections.Reflections;
 import javax.annotation.concurrent.Immutable;
 import java.util.Set;
 
-public class ClassPathScanner {
+public final class ClassPathScanner {
+
+    private ClassPathScanner() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static Set<Class<?>> findImmutableClasses(final String packageName) {
         Reflections reflections = new Reflections(packageName);

--- a/src/main/java/org/mutabilitydetector/unittesting/MutabilityMatchers.java
+++ b/src/main/java/org/mutabilitydetector/unittesting/MutabilityMatchers.java
@@ -29,7 +29,11 @@ import org.mutabilitydetector.IsImmutable;
 import org.mutabilitydetector.unittesting.matchers.IsImmutableMatcher;
 import org.mutabilitydetector.unittesting.matchers.reasons.NoReasonsAllowed;
 
-public class MutabilityMatchers {
+public final class MutabilityMatchers {
+
+    private MutabilityMatchers() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static Matcher<MutableReasonDetail> noReasonsAllowed() {
         return new NoReasonsAllowed();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat