### PR TITLE
ConfigurationBuilder: replace builder's results on merge

### DIFF
--- a/src/main/java/org/mutabilitydetector/ConfigurationBuilder.java
+++ b/src/main/java/org/mutabilitydetector/ConfigurationBuilder.java
@@ -347,8 +347,8 @@ public abstract class ConfigurationBuilder {
      */
     protected void mergeHardcodedResultsFrom(Configuration otherConfiguration) {
         Set<Wrapper<AnalysisResult>> union = 
-                Sets.union(newHashSet(transform(hardcodedResults.build(), TO_CLASSNAME_EQUIVALENCE_WRAPPER)), 
-                           copyOf(transform(otherConfiguration.hardcodedResults().values(), TO_CLASSNAME_EQUIVALENCE_WRAPPER)));
+                Sets.union(copyOf(transform(otherConfiguration.hardcodedResults().values(), TO_CLASSNAME_EQUIVALENCE_WRAPPER)),
+                           newHashSet(transform(hardcodedResults.build(), TO_CLASSNAME_EQUIVALENCE_WRAPPER)));
         
         Set<AnalysisResult> result = copyOf(transform(union, UNWRAP));
         

--- a/src/test/java/org/mutabilitydetector/ConfigurationBuilderTest.java
+++ b/src/test/java/org/mutabilitydetector/ConfigurationBuilderTest.java
@@ -72,23 +72,23 @@ public class ConfigurationBuilderTest {
 
     @Test
     public void mergeReplacesExistingHardcodedResultForClassWithCurrentHardcodedResult() throws Exception {
-        final Configuration existing = new ConfigurationBuilder() {
-            @Override public void configure() {
-                hardcodeResult(definitelyImmutable("hardcoded.in.both.Configurations"));
-                hardcodeResult(definitelyImmutable("only.in.existing.Configuration"));
-            }
-        }.build();
-        
         final AnalysisResult resultInCurrentConfig = analysisResult("hardcoded.in.both.Configurations",
                 IsImmutable.NOT_IMMUTABLE,
                 TestUtil.unusedMutableReasonDetail());
-        
-        final Configuration current = new ConfigurationBuilder() {
+
+        final Configuration mergedIn = new ConfigurationBuilder() {
             @Override public void configure() {
                 hardcodeResult(resultInCurrentConfig);
+                hardcodeResult(definitelyImmutable("only.in.existing.Configuration"));
+            }
+        }.build();
+
+        final Configuration current = new ConfigurationBuilder() {
+            @Override public void configure() {
+                hardcodeResult(definitelyImmutable("hardcoded.in.both.Configurations"));
                 hardcodeResult(definitelyImmutable("only.in.current.Configuration"));
 
-                mergeHardcodedResultsFrom(existing);
+                mergeHardcodedResultsFrom(mergedIn);
             }
         }.build();
         


### PR DESCRIPTION
This is intended to fix #93.