### PR TITLE
Issue 98 fix

### DIFF
--- a/src/main/java/org/mutabilitydetector/checkers/CollectionField.java
+++ b/src/main/java/org/mutabilitydetector/checkers/CollectionField.java
@@ -199,6 +199,22 @@ public abstract class CollectionField {
         }
 
         @Override
+        public void visitBaseType(char descriptor) {
+            if (state.isElementTypeArray) {
+                state.elementType = dotted("[" + descriptor);
+                storeNode();
+            } else {
+                throw new IllegalStateException("It shouldn't happen. Java doesn't support primitive generic types");
+            }
+        }
+
+        @Override
+        public SignatureVisitor visitArrayType() {
+            state.isElementTypeArray = true;
+            return withRoot(firstNonNull(lastStored, root));
+        }
+
+        @Override
         public SignatureVisitor visitTypeArgument(char wildcard) {
             state.wildcard = valueOf(wildcard);
 
@@ -228,6 +244,8 @@ public abstract class CollectionField {
             protected Dotted typeVariable;
             protected String wildcard;
             protected boolean seenOuterCollectionType = false;
+            boolean isElementTypeArray = false;
+
         }
     }
 

--- a/src/main/java/org/mutabilitydetector/checkers/CollectionField.java
+++ b/src/main/java/org/mutabilitydetector/checkers/CollectionField.java
@@ -228,7 +228,8 @@ public abstract class CollectionField {
 
         private GenericType createGenericType() {
             boolean isVariable = state.typeVariable != null;
-            return new GenericType(isVariable ? state.typeVariable : state.elementType, state.wildcard, isVariable);
+            return new GenericType(isVariable ? state.typeVariable : state.elementType, state.wildcard, isVariable,
+                    state.isElementTypeArray);
         }
 
         /**
@@ -253,27 +254,29 @@ public abstract class CollectionField {
         public final Dotted type;
         public final String wildcard;
         public final boolean isVariable;
+        public final boolean isArray;
 
-        public GenericType(Dotted type, String wildcard, boolean isVariable) {
+        public GenericType(Dotted type, String wildcard, boolean isVariable, boolean isArray) {
             this.type = type;
             this.wildcard = checkNotNull(wildcard, "wildcard");
             this.isVariable = isVariable;
+            this.isArray = isArray;
         }
 
         public static GenericType wildcard() {
-            return new GenericType(null, "?", false);
+            return new GenericType(null, "?", false, false);
         }
 
         public static GenericType exact(Dotted type) {
-            return new GenericType(type, "=", false);
+            return new GenericType(type, "=", false, false);
         }
 
         public static GenericType extends_(Dotted type) {
-            return new GenericType(type, "+", false);
+            return new GenericType(type, "+", false, false);
         }
 
         public static GenericType super_(Dotted type) {
-            return new GenericType(type, "-", false);
+            return new GenericType(type, "-", false, false);
         }
 
         @Override
@@ -341,9 +344,9 @@ public abstract class CollectionField {
 
         public GenericType withoutWildcard() {
             if ("?".equals(wildcard)) {
-                return new GenericType(fromClass(Object.class), "=", false);
+                return new GenericType(fromClass(Object.class), "=", false, false);
             }
-            return new GenericType(type, "=", false);
+            return new GenericType(type, "=", false, false);
         }
     }
 

--- a/src/main/java/org/mutabilitydetector/checkers/CollectionField.java
+++ b/src/main/java/org/mutabilitydetector/checkers/CollectionField.java
@@ -158,6 +158,8 @@ public abstract class CollectionField {
      * Constructs generics tree by visiting signature
      */
     private static class GenericCollectionVisitor extends SignatureVisitor {
+        public static final String OBJECT_ARRAY_PREFIX = "[L";
+        public static final String PRIMITIVE_ARRAY_PREFIX = "[";
         private GenericCollectionReaderState state;
         private Node root;
         private Node lastStored;
@@ -180,7 +182,7 @@ public abstract class CollectionField {
                 state.collectionType = dotted(name);
                 state.seenOuterCollectionType = true;
             } else {
-                state.elementType = dotted(name);
+                state.elementType = state.isElementTypeArray ? dotted(OBJECT_ARRAY_PREFIX + name) : dotted(name);
                 storeNode();
             }
         }
@@ -201,7 +203,7 @@ public abstract class CollectionField {
         @Override
         public void visitBaseType(char descriptor) {
             if (state.isElementTypeArray) {
-                state.elementType = dotted("[" + descriptor);
+                state.elementType = dotted(PRIMITIVE_ARRAY_PREFIX + descriptor);
                 storeNode();
             } else {
                 throw new IllegalStateException("It shouldn't happen. Java doesn't support primitive generic types");

--- a/src/main/java/org/mutabilitydetector/checkers/CollectionWithMutableElementTypeToFieldChecker.java
+++ b/src/main/java/org/mutabilitydetector/checkers/CollectionWithMutableElementTypeToFieldChecker.java
@@ -125,6 +125,8 @@ public final class CollectionWithMutableElementTypeToFieldChecker extends AsmMut
                     return true;
                 } else if (genericType.isVariable) {
                     return true;
+                } else if (genericType.isArray) {
+                    return true;
                 }
 
                 MutabilityLookup mutabilityLookup = mutableTypeInfo.resultOf(dotted(ownerClass), genericType.type, analysisInProgress);

--- a/src/test/benchmarks/org/mutabilitydetector/benchmarks/mutabletofield/CollectionFields.java
+++ b/src/test/benchmarks/org/mutabilitydetector/benchmarks/mutabletofield/CollectionFields.java
@@ -20,16 +20,7 @@ package org.mutabilitydetector.benchmarks.mutabletofield;
  * #L%
  */
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedSet;
+import java.util.*;
 import java.util.concurrent.ConcurrentSkipListSet;
 
 import org.mutabilitydetector.benchmarks.ImmutableExample;
@@ -169,6 +160,11 @@ public class CollectionFields {
             this.unmodifiableMap = Collections.unmodifiableMap(new HashMap<ImmutableExample, SOME_GENERIC_TYPE>(mapOfImmutableType));
         }
     }
+
+    public final static class CollectionWithByteArrayGenericType {
+        private final Collection<byte[]> unmodifiableMap = new ArrayList<>();
+    }
+
 
     public interface ImmutableContainer<E> {
         E get();

--- a/src/test/benchmarks/org/mutabilitydetector/benchmarks/mutabletofield/CollectionFields.java
+++ b/src/test/benchmarks/org/mutabilitydetector/benchmarks/mutabletofield/CollectionFields.java
@@ -162,9 +162,8 @@ public class CollectionFields {
     }
 
     public final static class CollectionWithByteArrayGenericType {
-        private final Collection<byte[]> unmodifiableMap = new ArrayList<>();
+        private final Collection<byte[]> byteArrayCollection = new ArrayList<>();
     }
-
 
     public interface ImmutableContainer<E> {
         E get();

--- a/src/test/benchmarks/org/mutabilitydetector/benchmarks/mutabletofield/CollectionFields.java
+++ b/src/test/benchmarks/org/mutabilitydetector/benchmarks/mutabletofield/CollectionFields.java
@@ -165,6 +165,10 @@ public class CollectionFields {
         private final Collection<byte[]> byteArrayCollection = new ArrayList<>();
     }
 
+    public final static class CollectionWithStringArrayGenericType {
+        private final Collection<String[]> stringArrayCollection = new ArrayList<>();
+    }
+
     public interface ImmutableContainer<E> {
         E get();
     }

--- a/src/test/java/org/mutabilitydetector/WellKnownJavaTypesTest.java
+++ b/src/test/java/org/mutabilitydetector/WellKnownJavaTypesTest.java
@@ -157,10 +157,9 @@ public class WellKnownJavaTypesTest {
         fail("Didn't find private class");
     }
 
-    // Currently fails due to a bug, remove the expected exception when fixed
-    @Test(expected = MutabilityAnalysisException.class)
+    @Test
     public void PNGMetadata() {
-        assertInstancesOf(PNGMetadata.class, areImmutable());
+        assertInstancesOf(PNGMetadata.class, areNotImmutable());
     }
 
 }

--- a/src/test/java/org/mutabilitydetector/WellKnownJavaTypesTest.java
+++ b/src/test/java/org/mutabilitydetector/WellKnownJavaTypesTest.java
@@ -23,7 +23,6 @@ package org.mutabilitydetector;
 
 
 import static org.junit.Assert.fail;
-import static org.mutabilitydetector.asmoverride.AsmVerifierFactory.ClassloadingOption.*;
 import static org.mutabilitydetector.unittesting.AllowedReason.allowingForSubclassing;
 import static org.mutabilitydetector.unittesting.AllowedReason.assumingFields;
 import static org.mutabilitydetector.unittesting.AllowedReason.provided;
@@ -42,18 +41,14 @@ import java.util.Date;
 import javax.management.ImmutableDescriptor;
 
 import com.sun.imageio.plugins.png.PNGMetadata;
-import com.sun.org.apache.xml.internal.security.encryption.XMLCipher;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mutabilitydetector.asmoverride.AsmVerifierFactory;
-import org.mutabilitydetector.checkers.MutabilityAnalysisException;
 import org.mutabilitydetector.junit.FalsePositive;
 import org.mutabilitydetector.junit.IncorrectAnalysisRule;
 
 import com.sun.corba.se.impl.activation.ORBD;
 import com.sun.java.swing.plaf.windows.WindowsTableHeaderUI;
-import org.mutabilitydetector.unittesting.MutabilityAsserter;
 
 public class WellKnownJavaTypesTest {
 

--- a/src/test/java/org/mutabilitydetector/benchmarks/CollectionWithMutableElementTypeToFieldCheckerTest.java
+++ b/src/test/java/org/mutabilitydetector/benchmarks/CollectionWithMutableElementTypeToFieldCheckerTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.mutabilitydetector.AnalysisResult;
 import org.mutabilitydetector.Configurations;
 import org.mutabilitydetector.MutableReasonDetail;
+import org.mutabilitydetector.benchmarks.mutabletofield.CollectionFields;
 import org.mutabilitydetector.benchmarks.mutabletofield.CollectionFields.HasImmutableContainerOfGenericType;
 import org.mutabilitydetector.benchmarks.mutabletofield.CollectionFields.HasImmutableContainerOfImmutableType;
 import org.mutabilitydetector.benchmarks.mutabletofield.CollectionFields.HasImmutableContainerOfMutableType;
@@ -105,6 +106,15 @@ public class CollectionWithMutableElementTypeToFieldCheckerTest {
 
         AnalysisResult result = runChecker(checker, HasImmutableContainerOfMutableType.class);
         assertThat(result, areNotImmutable());
+    }
+
+    @Test
+    public void raisesErrorWhenCollectionFieldTypeIsArrat() {
+        AnalysisResult result = runChecker(checker, CollectionFields.CollectionWithByteArrayGenericType.class);
+        assertThat(result, areNotImmutable());
+        assertThat(checker, hasReasons(COLLECTION_FIELD_WITH_MUTABLE_ELEMENT_TYPE));
+        assertThat(checker.checkerResult().reasons.iterator().next().message(),
+                containsString("(java.util.Collection<[B>)"));
     }
 
     @Test

--- a/src/test/java/org/mutabilitydetector/benchmarks/CollectionWithMutableElementTypeToFieldCheckerTest.java
+++ b/src/test/java/org/mutabilitydetector/benchmarks/CollectionWithMutableElementTypeToFieldCheckerTest.java
@@ -109,7 +109,7 @@ public class CollectionWithMutableElementTypeToFieldCheckerTest {
     }
 
     @Test
-    public void raisesErrorWhenCollectionFieldTypeIsArrat() {
+    public void raisesErrorWhenCollectionFieldTypeIsPrimitiveArray() {
         AnalysisResult result = runChecker(checker, CollectionFields.CollectionWithByteArrayGenericType.class);
         assertThat(result, areNotImmutable());
         assertThat(checker, hasReasons(COLLECTION_FIELD_WITH_MUTABLE_ELEMENT_TYPE));

--- a/src/test/java/org/mutabilitydetector/benchmarks/CollectionWithMutableElementTypeToFieldCheckerTest.java
+++ b/src/test/java/org/mutabilitydetector/benchmarks/CollectionWithMutableElementTypeToFieldCheckerTest.java
@@ -22,6 +22,7 @@ package org.mutabilitydetector.benchmarks;
 
 
 import com.google.common.collect.ImmutableSet;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mutabilitydetector.AnalysisResult;
 import org.mutabilitydetector.Configurations;
@@ -115,6 +116,20 @@ public class CollectionWithMutableElementTypeToFieldCheckerTest {
         assertThat(checker, hasReasons(COLLECTION_FIELD_WITH_MUTABLE_ELEMENT_TYPE));
         assertThat(checker.checkerResult().reasons.iterator().next().message(),
                 containsString("(java.util.Collection<[B>)"));
+    }
+
+
+    /**
+     * FIXME Wrong error message. {@link org.mutabilitydetector.locations.Dotted#dotted(String)} method removed
+     */
+    @Test
+    @Ignore
+    public void raisesErrorWhenCollectionFieldTypeIsObjectArray() {
+        AnalysisResult result = runChecker(checker, CollectionFields.CollectionWithStringArrayGenericType.class);
+        assertThat(result, areNotImmutable());
+        assertThat(checker, hasReasons(COLLECTION_FIELD_WITH_MUTABLE_ELEMENT_TYPE));
+        assertThat(checker.checkerResult().reasons.iterator().next().message(),
+                containsString("(java.util.Collection<[Ljava.lang.Sring>)"));
     }
 
     @Test

--- a/src/test/java/org/mutabilitydetector/checkers/CollectionFieldTest.java
+++ b/src/test/java/org/mutabilitydetector/checkers/CollectionFieldTest.java
@@ -124,7 +124,7 @@ public class CollectionFieldTest {
     }
 
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void recognisesPrimitiveArrayAsGenericTypeOfCollectionField() throws Exception {
         String[] descAndSignature = descAndSignatureOfSingleFieldIn(DeclaresGenericCollectionButAssignsRawCollection.class);
 

--- a/src/test/java/org/mutabilitydetector/checkers/CollectionFieldTest.java
+++ b/src/test/java/org/mutabilitydetector/checkers/CollectionFieldTest.java
@@ -21,7 +21,9 @@ package org.mutabilitydetector.checkers;
  */
 
 
+import org.junit.Ignore;
 import org.junit.Test;
+import org.mutabilitydetector.benchmarks.mutabletofield.CollectionFields;
 import org.mutabilitydetector.checkers.CollectionField.GenericType;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -30,8 +32,6 @@ import org.objectweb.asm.Opcodes;
 
 import java.io.IOException;
 import java.lang.ref.Reference;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -126,11 +126,27 @@ public class CollectionFieldTest {
 
     @Test
     public void recognisesPrimitiveArrayAsGenericTypeOfCollectionField() throws Exception {
-        String[] descAndSignature = descAndSignatureOfSingleFieldIn(DeclaresGenericCollectionButAssignsRawCollection.class);
+        String[] descAndSignature = descAndSignatureOfSingleFieldIn(CollectionFields
+                .CollectionWithByteArrayGenericType.class);
 
         CollectionField collectionField = CollectionField.from(descAndSignature[0], descAndSignature[1]);
 
-        assertThat(collectionField.getGenericParameterTypes(), contains(exact(fromClass(int[].class))));
+        assertThat(collectionField.getGenericParameterTypes(), contains(exact(fromClass(byte[].class))));
+    }
+
+    /**
+     *  FIXME it passes because in both cases method {@link org.mutabilitydetector.locations.Dotted#dotted(String)}
+     *  removes '[L' from signature. However we have generic type = java.lang.String instead [LjavaLangString
+     */
+    @Test
+    @Ignore
+    public void recognisesObjectArrayAsGenericTypeOfCollectionField() throws Exception {
+        String[] descAndSignature = descAndSignatureOfSingleFieldIn(CollectionFields
+                .CollectionWithStringArrayGenericType.class);
+
+        CollectionField collectionField = CollectionField.from(descAndSignature[0], descAndSignature[1]);
+
+        assertThat(collectionField.getGenericParameterTypes(), contains(exact(fromClass(String[].class))));
     }
 
     private static class WithGenericListField {
@@ -160,10 +176,6 @@ public class CollectionFieldTest {
 
     private static class WithWildcardGenericsListField {
         public List<?> listOfString;
-    }
-
-    private static class DeclaresGenericCollectionButAssignsRawCollection {
-        public final Collection<int[]> genericListWithRawTypeAssigned = new ArrayList<>();
     }
 
     private String[] descAndSignatureOfSingleFieldIn(Class<?> class1) throws IOException {


### PR DESCRIPTION
Fix for issue #98 

1. Fixed issue for collections with primitive array generic type. Overrode  visitors methods for arrays and base types. It helps with test case in CollectionFieldTests
2. Previous fix doesn't help for PNGMeradata mutability check. There was next problem: ClassNotFound exception during loading resource for class with name [B(byte array). To avoid loading resource for such kind of classes I added check to CollectionWithMutableElementTypeToFieldChecker. If generic type is array then collection is mutable, because arrays are always mutable
3. Also I noticed that CollectionField class return wrong result for collection with array of object used for generic type: Collection<String[]>. For such kind of classes CollectionField  returns result: Collection<java.lang.String> instead Collection<[Ljava.lang.String>. Cause of this problem is class ClassNameConverter which remove '[L' from class name. That's why analyzer return wrong error message for such collections. I've added 2 test scenarios, put FIXME comment and ignored them. To fix this issue we need to know why ClassNameConverter removes [L symbols