### PR TITLE
Added xml-security-impl dependency to fix build failure issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>com.sun.xml.security</groupId>
+      <artifactId>xml-security-impl</artifactId>
+      <version>1.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.10.19</version>


### PR DESCRIPTION
Currently a clean build on Java 1.8.0_60 fails due to a dependency on an internal package (which I assume is no longer present in that version of Java):

```
joe$ mvn -q install
[ERROR] COMPILATION ERROR : 
[ERROR] /Users/Joe/Projects/MutabilityDetector/src/test/java/org/mutabilitydetector/WellKnownJavaTypesTest.java:[45,59] package com.sun.org.apache.xml.internal.security.encryption does not exist
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.3:testCompile (default-testCompile) on project MutabilityDetector: Compilation failure
[ERROR] /Users/Joe/Projects/MutabilityDetector/src/test/java/org/mutabilitydetector/WellKnownJavaTypesTest.java:[45,59] package com.sun.org.apache.xml.internal.security.encryption does not exist

```

The xml-security-impl dependency includes this missing package and solves the [problem from build 111](https://travis-ci.org/MutabilityDetector/MutabilityDetector/builds/191987651).