### PR TITLE
Added TimingUtil to make the SessionResultsFormatter's seconds taken …

### DIFF
--- a/src/main/java/org/mutabilitydetector/cli/SessionResultsFormatter.java
+++ b/src/main/java/org/mutabilitydetector/cli/SessionResultsFormatter.java
@@ -28,10 +28,10 @@ import org.mutabilitydetector.IsImmutable;
 import org.mutabilitydetector.MutableReasonDetail;
 import org.mutabilitydetector.cli.CommandLineOptions.ReportMode;
 import org.mutabilitydetector.locations.Dotted;
+import org.mutabilitydetector.misc.TimingUtil;
 
 import javax.annotation.concurrent.Immutable;
 import java.io.Serializable;
-import java.lang.management.ManagementFactory;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -48,13 +48,15 @@ public final class SessionResultsFormatter {
     private final ReportMode reportMode;
     private final Collection<Dotted> classesToReport;
     private final BatchAnalysisOptions options;
-
+    private TimingUtil timingUtil;
+    
     public SessionResultsFormatter(BatchAnalysisOptions options, ClassListReaderFactory readerFactory) {
         this.options = options;
         this.verbose = options.verbose();
         this.showSummary = options.showSummary();
         this.reportMode = options.reportMode();
         this.classesToReport = getClassesToReport(options.isUsingClassList(), readerFactory);
+        this.timingUtil = new TimingUtil();
     }
 
     public StringBuilder format(Iterable<AnalysisResult> results, Iterable<AnalysisError> errors) {
@@ -111,7 +113,7 @@ public final class SessionResultsFormatter {
         output.append(String.format("%n\t%d %s%n", total, "Total number of classes scanned."));
         output.append(String.format("\t%d %s%n", totalImmutable, "IMMUTABLE class(es)."));
         output.append(String.format("\t%d %s%n", totalMutable,  "NOT_IMMUTABLE class(es)."));
-        final long processRuntime =System.currentTimeMillis() - ManagementFactory.getRuntimeMXBean().getStartTime()  ;
+        final long processRuntime = timingUtil.getCurrentTimeMillis() - timingUtil.getVMStartTimeMillis();
         output.append(String.format("\t%d %s%n", processRuntime/1000, "seconds runtime."));
     }
 
@@ -161,6 +163,10 @@ public final class SessionResultsFormatter {
             return first.className.asString().compareToIgnoreCase(second.className.asString());
         }
 
+    }
+
+    public void setTimingUtil(TimingUtil timingUtil) {
+        this.timingUtil = timingUtil;
     }
 
 }

--- a/src/main/java/org/mutabilitydetector/misc/TimingUtil.java
+++ b/src/main/java/org/mutabilitydetector/misc/TimingUtil.java
@@ -1,0 +1,50 @@
+package org.mutabilitydetector.misc;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.lang.management.ManagementFactory;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+/*
+ * #%L
+ * MutabilityDetector
+ * %%
+ * Copyright (C) 2008 - 2014 Graham Allan
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+@Immutable
+public class TimingUtil {
+    
+    private Clock jvmStartTimeClock;
+    private Clock currentTimeClock;
+    
+    public TimingUtil() {
+        long jvmStartTime = ManagementFactory.getRuntimeMXBean().getStartTime();
+        jvmStartTimeClock = Clock.fixed(Instant.ofEpochMilli(jvmStartTime), ZoneId.systemDefault());
+        currentTimeClock = Clock.systemDefaultZone();
+    }
+
+    public long getCurrentTimeMillis() {
+        return currentTimeClock.millis();
+    }
+    
+    public long getVMStartTimeMillis() {
+        return jvmStartTimeClock.millis();
+    }
+
+}

--- a/src/test/java/org/mutabilitydetector/cli/SessionResultsFormatterTest.java
+++ b/src/test/java/org/mutabilitydetector/cli/SessionResultsFormatterTest.java
@@ -48,6 +48,7 @@ import org.mutabilitydetector.IsImmutable;
 import org.mutabilitydetector.MutableReasonDetail;
 import org.mutabilitydetector.cli.CommandLineOptions.ReportMode;
 import org.mutabilitydetector.locations.CodeLocation.FieldLocation;
+import org.mutabilitydetector.misc.TimingUtil;
 
 public class SessionResultsFormatterTest {
 
@@ -119,6 +120,10 @@ public class SessionResultsFormatterTest {
         when(options.reportMode()).thenReturn(ReportMode.ALL);
         when(options.isUsingClassList()).thenReturn(false);
         when(options.showSummary()).thenReturn(true);
+        
+        TimingUtil timingUtil = mock(TimingUtil.class);
+        when(timingUtil.getCurrentTimeMillis()).thenReturn(23000l);
+        when(timingUtil.getVMStartTimeMillis()).thenReturn(16000l);
 
         AnalysisSession analysisSession = mock(AnalysisSession.class);
         Collection<AnalysisResult> analysisResults = Arrays.asList(analysisResult("a.b.c",
@@ -133,6 +138,7 @@ public class SessionResultsFormatterTest {
         when(analysisSession.getResults()).thenReturn(analysisResults);
 
         SessionResultsFormatter formatter = new SessionResultsFormatter(options, unusedReaderFactory);
+        formatter.setTimingUtil(timingUtil);
 
         StringBuilder result = formatter.format(analysisSession.getResults(), analysisSession.getErrors());
 
@@ -143,7 +149,7 @@ public class SessionResultsFormatterTest {
                         containsString("3 Total number of classes scanned." + newline),
                         containsString("2 IMMUTABLE class(es)." + newline),
                         containsString("1 NOT_IMMUTABLE class(es)." + newline),
-                        containsString("seconds runtime." + newline)
+                        containsString("7 seconds runtime." + newline)
                         ));
     }
 }


### PR DESCRIPTION
…testable (issue #92)

The test class for SessionResultsFormatter can now verify that the seconds taken will be correct.
I'm not sure if adding a setter for TimingUtil is the best approach to inject the mock - let me know what you think.