### PR TITLE
Update POM to lates ASM and shade plugin. This change allows Mutabili…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.4.2</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -309,8 +309,8 @@
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-debug-all</artifactId>
-      <version>5.0.3</version>
+      <artifactId>asm</artifactId>
+      <version>6.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Update POM to lates ASM and shade plugin. This change allows MutabilityDetector to work with Java 1.9.

Tested with both Java 1.9 and Java 1.8.

To compile with the 1.9 JDK the following is needed in the POM

```
      <plugin>
        <groupId>org.apache.maven.plugins</groupId>
        <artifactId>maven-surefire-plugin</artifactId>
        <version>2.20.1</version>
        <configuration>
          <argLine>--add-modules java.corba</argLine>
        </configuration>
      </plugin>
```