### PR TITLE
Consider immutable classes for generic fields

### DIFF
--- a/src/test/java/org/mutabilitydetector/unittesting/matchers/reasons/ProvidedOtherClassTest.java
+++ b/src/test/java/org/mutabilitydetector/unittesting/matchers/reasons/ProvidedOtherClassTest.java
@@ -30,6 +30,9 @@ import static org.mutabilitydetector.MutabilityReason.COLLECTION_FIELD_WITH_MUTA
 import static org.mutabilitydetector.MutabilityReason.MUTABLE_TYPE_TO_FIELD;
 import static org.mutabilitydetector.MutableReasonDetail.newMutableReasonDetail;
 import static org.mutabilitydetector.locations.Dotted.dotted;
+import static org.mutabilitydetector.unittesting.AllowedReason.provided;
+import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
+import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
 import org.hamcrest.Matcher;
 import org.junit.Rule;
@@ -133,5 +136,31 @@ public class ProvidedOtherClassTest {
         assertTrue(matcher.matches(reason));
     }
 
+    /**
+     * When a class is declared as immutable with a type parameter that is
+     * considered immutable, then a field with that type should also be considered
+     * immutable.
+     *
+     * @see {@link https://github.com/MutabilityDetector/MutabilityDetector/issues/104}
+     */
+    @Test
+    public final void considerProvidedImmutableClassesForGenericFields() {
+        assertInstancesOf(ClassWithGenericField.class, areImmutable(), provided(SomeInterface.class).isAlsoImmutable());
+    }
+
+    protected static interface SomeInterface {
+    }
+
+    protected static final class ClassWithGenericField<T extends SomeInterface> {
+        private final T field;
+
+        public ClassWithGenericField(final T field) {
+            this.field = field;
+        }
+
+        public T getField() {
+            return field;
+        }
+    }
 
 }


### PR DESCRIPTION
Given a class with a generic type parameter T, where T is guaranteed to be an instance of U. If the class has a final field of type T and U has been guaranteed to be immutable, then the class will also be considered immutable.

This implementation modifies the "allowing" `Matcher` only. It uses reflection to determine if the field type being assigned had previously been specified immutable. In #104, it is suggested that generic information can be captured and stored for later use. However, I did not follow this approach as it seemed more invasive (would require capturing that in `FieldLocation`) and the generic information was available via Reflection. I can, however, change this if desired.