### PR TITLE
Capture declared type in FieldLocation

### DIFF
--- a/src/main/java/org/mutabilitydetector/checkers/ArrayFieldMutabilityChecker.java
+++ b/src/main/java/org/mutabilitydetector/checkers/ArrayFieldMutabilityChecker.java
@@ -26,6 +26,7 @@ import static org.mutabilitydetector.checkers.AccessModifierQuery.field;
 import static org.mutabilitydetector.locations.CodeLocation.FieldLocation.fieldLocation;
 
 import org.mutabilitydetector.MutabilityReason;
+import org.mutabilitydetector.locations.Dotted;
 import org.mutabilitydetector.locations.CodeLocation.ClassLocation;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.Type;
@@ -45,7 +46,7 @@ public class ArrayFieldMutabilityChecker extends AsmMutabilityChecker {
              */
             if (isArray(desc) && !isTheInternalImmutableArrayFieldInAnEnum(name)) {
                 setResult("Field is an array.",
-                        fieldLocation(name, ClassLocation.fromInternalName(ownerClass)),
+                        fieldLocation(name, ClassLocation.fromInternalName(ownerClass), Dotted.fromFieldDescription(desc)),
                         MutabilityReason.ARRAY_TYPE_INHERENTLY_MUTABLE);
             }
         }

--- a/src/main/java/org/mutabilitydetector/checkers/CollectionWithMutableElementTypeToFieldChecker.java
+++ b/src/main/java/org/mutabilitydetector/checkers/CollectionWithMutableElementTypeToFieldChecker.java
@@ -37,6 +37,7 @@ import org.objectweb.asm.tree.FieldInsnNode;
 import org.objectweb.asm.tree.analysis.BasicValue;
 import org.objectweb.asm.tree.analysis.Frame;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static com.google.common.collect.Maps.newHashMap;
@@ -53,6 +54,7 @@ public final class CollectionWithMutableElementTypeToFieldChecker extends AsmMut
     private final JdkCollectionTypes jdkCollectionTypes = new JdkCollectionTypes();
     
     private final Map<String, String> fieldSignatures = newHashMap();
+    private final Map<String, Dotted> fieldTypes = new HashMap<>();
     private final AnalysisInProgress analysisInProgress;
     
     public CollectionWithMutableElementTypeToFieldChecker(
@@ -69,6 +71,7 @@ public final class CollectionWithMutableElementTypeToFieldChecker extends AsmMut
     @Override
     public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
         fieldSignatures.put(name, signature);
+        fieldTypes.put(name, Dotted.fromFieldDescription(desc));
         return super.visitField(access, name, desc, signature, value);
     }
     
@@ -113,7 +116,7 @@ public final class CollectionWithMutableElementTypeToFieldChecker extends AsmMut
                 
                 if (!collectionField.isGeneric() || anyGenericParameterTypesAreMutable(genericParameters)) {
                     setResult(format("Field can have collection with mutable element type (%s) assigned to it.", collectionField.asString()),
-                              fieldLocation(fieldName, ClassLocation.fromInternalName(ownerClass)),
+                              fieldLocation(fieldName, ClassLocation.fromInternalName(ownerClass), fieldTypes.get(fieldName)),
                               MutabilityReason.COLLECTION_FIELD_WITH_MUTABLE_ELEMENT_TYPE);
                 }
             }

--- a/src/main/java/org/mutabilitydetector/checkers/CollectionWithMutableElementTypeToFieldChecker.java
+++ b/src/main/java/org/mutabilitydetector/checkers/CollectionWithMutableElementTypeToFieldChecker.java
@@ -37,7 +37,6 @@ import org.objectweb.asm.tree.FieldInsnNode;
 import org.objectweb.asm.tree.analysis.BasicValue;
 import org.objectweb.asm.tree.analysis.Frame;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import static com.google.common.collect.Maps.newHashMap;
@@ -54,7 +53,6 @@ public final class CollectionWithMutableElementTypeToFieldChecker extends AsmMut
     private final JdkCollectionTypes jdkCollectionTypes = new JdkCollectionTypes();
     
     private final Map<String, String> fieldSignatures = newHashMap();
-    private final Map<String, Dotted> fieldTypes = new HashMap<>();
     private final AnalysisInProgress analysisInProgress;
     
     public CollectionWithMutableElementTypeToFieldChecker(
@@ -71,7 +69,6 @@ public final class CollectionWithMutableElementTypeToFieldChecker extends AsmMut
     @Override
     public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
         fieldSignatures.put(name, signature);
-        fieldTypes.put(name, Dotted.fromFieldDescription(desc));
         return super.visitField(access, name, desc, signature, value);
     }
     
@@ -116,7 +113,7 @@ public final class CollectionWithMutableElementTypeToFieldChecker extends AsmMut
                 
                 if (!collectionField.isGeneric() || anyGenericParameterTypesAreMutable(genericParameters)) {
                     setResult(format("Field can have collection with mutable element type (%s) assigned to it.", collectionField.asString()),
-                              fieldLocation(fieldName, ClassLocation.fromInternalName(ownerClass), fieldTypes.get(fieldName)),
+                              fieldLocation(fieldName, ClassLocation.fromInternalName(ownerClass), Dotted.fromFieldInsnNode(fieldInsnNode)),
                               MutabilityReason.COLLECTION_FIELD_WITH_MUTABLE_ELEMENT_TYPE);
                 }
             }

--- a/src/main/java/org/mutabilitydetector/checkers/MutableTypeToFieldChecker.java
+++ b/src/main/java/org/mutabilitydetector/checkers/MutableTypeToFieldChecker.java
@@ -45,7 +45,6 @@ import org.objectweb.asm.tree.FieldInsnNode;
 import org.objectweb.asm.tree.analysis.BasicValue;
 import org.objectweb.asm.tree.analysis.Frame;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -66,9 +65,6 @@ public final class MutableTypeToFieldChecker extends AsmMutabilityChecker {
     private final Map<String, String> genericFields = Maps.newHashMap();
     private final AnalysisInProgress analysisInProgress;
     private final Map<String, String> typeSignatureByFieldName = Maps.newHashMap();
-    private final Map<String, Dotted> typeByFieldName = new HashMap<>(); // distinct from typeSignatureByFieldName as
-                                                                         // "signature" is not always specified when
-                                                                         // visiting a field
 
     public MutableTypeToFieldChecker(TypeStructureInformation info,
                                      MutableTypeInformation mutableTypeInfo,
@@ -100,7 +96,6 @@ public final class MutableTypeToFieldChecker extends AsmMutabilityChecker {
     public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
         if (signature == null) { return null ; }
         typeSignatureByFieldName.put(name, signature);
-        typeByFieldName.put(name, Dotted.fromFieldDescription(desc));
         
         GenericFieldVisitor visitor = new GenericFieldVisitor();
         new SignatureReader(signature).acceptType(visitor);
@@ -165,7 +160,7 @@ public final class MutableTypeToFieldChecker extends AsmMutabilityChecker {
             int sort = typeAssignedToField.getSort();
             String fieldName = fieldInsnNode.name;
             FieldLocation fieldLocation = fieldLocation(fieldName, ClassLocation.fromInternalName(ownerClass),
-                    typeByFieldName.get(fieldName));
+                    Dotted.fromFieldInsnNode(fieldInsnNode));
 
             switch (sort) {
             case Type.OBJECT:

--- a/src/main/java/org/mutabilitydetector/checkers/NonFinalFieldChecker.java
+++ b/src/main/java/org/mutabilitydetector/checkers/NonFinalFieldChecker.java
@@ -26,6 +26,7 @@ import static org.mutabilitydetector.checkers.AccessModifierQuery.field;
 import static org.mutabilitydetector.locations.CodeLocation.FieldLocation.fieldLocation;
 
 import org.mutabilitydetector.MutabilityReason;
+import org.mutabilitydetector.locations.Dotted;
 import org.mutabilitydetector.locations.CodeLocation.ClassLocation;
 import org.objectweb.asm.FieldVisitor;
 
@@ -35,7 +36,7 @@ public final class NonFinalFieldChecker extends AsmMutabilityChecker {
     public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
         if (field(access).isNotFinal() && field(access).isNotStatic()) {
             setResult("Field is not final, if shared across threads the Java Memory Model will not guarantee it is initialised before it is read.",
-                    fieldLocation(name, ClassLocation.fromInternalName(ownerClass)),
+                    fieldLocation(name, ClassLocation.fromInternalName(ownerClass), Dotted.fromFieldDescription(desc)),
                     MutabilityReason.NON_FINAL_FIELD);
         }
         return super.visitField(access, name, desc, signature, value);

--- a/src/main/java/org/mutabilitydetector/checkers/OldSetterMethodChecker.java
+++ b/src/main/java/org/mutabilitydetector/checkers/OldSetterMethodChecker.java
@@ -34,6 +34,7 @@ import org.mutabilitydetector.checkers.VarStack.VarStackSnapshot;
 import org.mutabilitydetector.checkers.info.MethodIdentifier;
 import org.mutabilitydetector.checkers.info.PrivateMethodInvocationInformation;
 import org.mutabilitydetector.locations.CodeLocation.FieldLocation;
+import org.mutabilitydetector.locations.Dotted;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.FieldInsnNode;
@@ -113,7 +114,7 @@ public final class OldSetterMethodChecker extends AsmMutabilityChecker {
         private void detectInStaticMethod(FieldInsnNode fieldInsnNode) {
             String ownerOfReassignedField = fieldInsnNode.owner;
             if (reassignedIsThisType(ownerOfReassignedField) && assignmentIsNotOnAParameter(fieldInsnNode)) {
-                setIsImmutableResult(fieldInsnNode.name);
+                setIsImmutableResult(fieldInsnNode.name, Dotted.fromFieldInsnNode(fieldInsnNode));
             }
         }
 
@@ -136,7 +137,7 @@ public final class OldSetterMethodChecker extends AsmMutabilityChecker {
             VarStackSnapshot varStackSnapshot = varStack.next();
             if (varStackSnapshot.thisObjectWasAddedToStack()) {
                 // Throwing an NPE, assuming it's mutable for now.
-                setIsImmutableResult(fieldInsnNode.name);
+                setIsImmutableResult(fieldInsnNode.name, Dotted.fromFieldInsnNode(fieldInsnNode));
             }
         }
 
@@ -154,9 +155,9 @@ public final class OldSetterMethodChecker extends AsmMutabilityChecker {
             varStack.visitVarInsn(var);
         }
 
-        private void setIsImmutableResult(String fieldName) {
+        private void setIsImmutableResult(String fieldName, Dotted fieldType) {
             setResult(format("Field [%s] can be reassigned within method [%s]", fieldName, this.name), 
-                      FieldLocation.fieldLocation(fieldName, fromInternalName(owner)), 
+                      FieldLocation.fieldLocation(fieldName, fromInternalName(owner), fieldType), 
                       MutabilityReason.FIELD_CAN_BE_REASSIGNED);
         }
 

--- a/src/main/java/org/mutabilitydetector/checkers/PublishedNonFinalFieldChecker.java
+++ b/src/main/java/org/mutabilitydetector/checkers/PublishedNonFinalFieldChecker.java
@@ -27,6 +27,7 @@ import static org.mutabilitydetector.locations.CodeLocation.FieldLocation.fieldL
 
 import org.mutabilitydetector.MutabilityReason;
 import org.mutabilitydetector.locations.CodeLocation.ClassLocation;
+import org.mutabilitydetector.locations.Dotted;
 import org.objectweb.asm.FieldVisitor;
 
 public final class PublishedNonFinalFieldChecker extends AsmMutabilityChecker {
@@ -35,7 +36,7 @@ public final class PublishedNonFinalFieldChecker extends AsmMutabilityChecker {
     public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
         if (field(access).isNotPrivate() && field(access).isNotFinal()) {
             setResult("Field is visible outwith this class, and is not declared final.",
-                    fieldLocation(name, ClassLocation.fromInternalName(ownerClass)),
+                    fieldLocation(name, ClassLocation.fromInternalName(ownerClass), Dotted.fromFieldDescription(desc)),
                     MutabilityReason.PUBLISHED_NON_FINAL_FIELD);
         }
         return super.visitField(access, name, desc, signature, value);

--- a/src/main/java/org/mutabilitydetector/checkers/settermethod/AbstractSetterMethodChecker.java
+++ b/src/main/java/org/mutabilitydetector/checkers/settermethod/AbstractSetterMethodChecker.java
@@ -35,6 +35,7 @@ import org.mutabilitydetector.Reason;
 import org.mutabilitydetector.checkers.AsmMutabilityChecker;
 import org.mutabilitydetector.locations.CodeLocation.ClassLocation;
 import org.mutabilitydetector.locations.CodeLocation.FieldLocation;
+import org.mutabilitydetector.locations.Dotted;
 import org.objectweb.asm.*;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.FieldNode;
@@ -102,7 +103,7 @@ abstract class AbstractSetterMethodChecker extends AsmMutabilityChecker {
             result = new FieldNode(access, name, desc, signature, value);
             candidatesInitialisersMapping.addCandidate((FieldNode) result);
         } else if (field(access).isNotFinal() && field(access).isNotStatic()) {
-            setNonFinalFieldResult(name);
+            setNonFinalFieldResult(name, Dotted.fromFieldDescription(desc));
         }
         if (super.visitField(0, null, null, null, null) == result) {
             result = classNode.visitField(access, name, desc, signature, value);
@@ -180,14 +181,14 @@ abstract class AbstractSetterMethodChecker extends AsmMutabilityChecker {
         super.setResult(message, fromInternalName(classNode.name), reason);
     }
 
-    final void setNonFinalFieldResult(final String variableName) {
+    final void setNonFinalFieldResult(final String variableName, final Dotted variableType) {
         final String msg = "Field is not final, if shared across threads the Java Memory Model will not"
                 + " guarantee it is initialised before it is read.";
-        setNonFinalFieldResult(msg, variableName);
+        setNonFinalFieldResult(msg, variableName, variableType);
     }
 
-    final void setNonFinalFieldResult(final String message, final String variableName) {
-        final FieldLocation location = fieldLocation(variableName, ClassLocation.fromInternalName(ownerClass));
+    final void setNonFinalFieldResult(final String message, final String variableName, final Dotted variableType) {
+        final FieldLocation location = fieldLocation(variableName, ClassLocation.fromInternalName(ownerClass), variableType);
         setResult(message, location, MutabilityReason.NON_FINAL_FIELD);
     }
 
@@ -201,8 +202,8 @@ abstract class AbstractSetterMethodChecker extends AsmMutabilityChecker {
         setResultForClass(message, MutabilityReason.FIELD_CAN_BE_REASSIGNED);
     }
 
-    final void setMutableTypeToFieldResult(final String message, final String variableName) {
-        final FieldLocation location = fieldLocation(variableName, ClassLocation.fromInternalName(ownerClass));
+    final void setMutableTypeToFieldResult(final String message, final String variableName, final Dotted variableType) {
+        final FieldLocation location = fieldLocation(variableName, ClassLocation.fromInternalName(ownerClass), variableType);
         setResult(message, location, MutabilityReason.MUTABLE_TYPE_TO_FIELD);
     }
 

--- a/src/main/java/org/mutabilitydetector/checkers/settermethod/AssignmentGuardVerifier.java
+++ b/src/main/java/org/mutabilitydetector/checkers/settermethod/AssignmentGuardVerifier.java
@@ -37,6 +37,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 import org.mutabilitydetector.MutabilityReason;
 import org.mutabilitydetector.checkers.settermethod.CandidatesInitialisersMapping.Entry;
 import org.mutabilitydetector.checkers.settermethod.CandidatesInitialisersMapping.Initialisers;
+import org.mutabilitydetector.locations.Dotted;
 import org.objectweb.asm.tree.*;
 
 /**
@@ -111,14 +112,10 @@ final class AssignmentGuardVerifier {
     private final class NonNullCheckAssignmentGuardVerifier {
     
         private final FieldNode candidate;
-        private final ControlFlowBlock controlFlowBlock;
-        private final JumpInsn assignmentGuard;
     
         public NonNullCheckAssignmentGuardVerifier(final FieldNode theCandidate,
                 final ControlFlowBlock theControlFlowBlock, final JumpInsn theAssignmentGuard) {
             candidate = theCandidate;
-            controlFlowBlock = theControlFlowBlock;
-            assignmentGuard = theAssignmentGuard;
         }
     
         public void verify() {
@@ -126,7 +123,8 @@ final class AssignmentGuardVerifier {
             if (isNotPossibleInitialValueOfCandidate(DefaultUnknownTypeValue.getInstanceForNull(), candidate)) {
                 final String msgTemplate = "The assignment guard for lazy field [%s] should check against null. "
                         + "Otherwise the field gets never initialised.";
-                setterMethodChecker.setNonFinalFieldResult(format(msgTemplate, candidateName), candidateName);
+                setterMethodChecker.setNonFinalFieldResult(format(msgTemplate, candidateName), candidateName,
+                        Dotted.fromFieldNode(candidate));
             }
         }
     

--- a/src/main/java/org/mutabilitydetector/checkers/settermethod/EffectiveAssignmentInsnVerifier.java
+++ b/src/main/java/org/mutabilitydetector/checkers/settermethod/EffectiveAssignmentInsnVerifier.java
@@ -29,6 +29,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Collection;
 import java.util.List;
 
+import org.mutabilitydetector.locations.Dotted;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AbstractInsnNode;
@@ -148,7 +149,7 @@ final class EffectiveAssignmentInsnVerifier {
             } else {
                 final String message = "Value for lazy field is not a constant but stems from a method which is "
                         + "neither parameterless nor an instance or class method.";
-                setterMethodChecker.setMutableTypeToFieldResult(message, candidateName);
+                setterMethodChecker.setMutableTypeToFieldResult(message, candidateName, Dotted.fromFieldNode(candidate));
             }
         }
     }

--- a/src/main/java/org/mutabilitydetector/checkers/settermethod/SetterMethodChecker.java
+++ b/src/main/java/org/mutabilitydetector/checkers/settermethod/SetterMethodChecker.java
@@ -42,7 +42,9 @@ import org.mutabilitydetector.checkers.info.MethodIdentifier;
 import org.mutabilitydetector.checkers.info.PrivateMethodInvocationInformation;
 import org.mutabilitydetector.checkers.settermethod.CandidatesInitialisersMapping.Entry;
 import org.mutabilitydetector.checkers.settermethod.CandidatesInitialisersMapping.Initialisers;
+import org.mutabilitydetector.locations.Dotted;
 import org.mutabilitydetector.locations.Slashed;
+import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.FieldNode;
 import org.objectweb.asm.tree.MethodNode;
 
@@ -131,7 +133,7 @@ public final class SetterMethodChecker extends AbstractSetterMethodChecker {
         final Collection<FieldNode> unassociatedVariables = candidatesInitialisersMapping
                 .removeAndGetCandidatesWithoutInitialisingMethod();
         for (final FieldNode unassociatedVariable : unassociatedVariables) {
-            setNonFinalFieldResult(unassociatedVariable.name);
+            setNonFinalFieldResult(unassociatedVariable.name, Dotted.fromFieldNode(unassociatedVariable));
         }
     }
 

--- a/src/main/java/org/mutabilitydetector/locations/CodeLocation.java
+++ b/src/main/java/org/mutabilitydetector/locations/CodeLocation.java
@@ -132,14 +132,16 @@ public abstract class CodeLocation<T extends CodeLocation<T>> implements Compara
 
         private final @Nonnull String fieldName;
         private final @Nonnull ClassLocation ownerOfField;
+        private final @Nonnull Dotted fieldType;
 
-        private FieldLocation(String fieldName, ClassLocation ownerOfField) {
+        private FieldLocation(String fieldName, ClassLocation ownerOfField, Dotted fieldType) {
             this.fieldName = fieldName;
             this.ownerOfField = ownerOfField;
+            this.fieldType = fieldType;
         }
 
-        public static FieldLocation fieldLocation(String fieldName, ClassLocation ownerOfField) {
-            return new FieldLocation(fieldName, ownerOfField);
+        public static FieldLocation fieldLocation(String fieldName, ClassLocation ownerOfField, Dotted fieldType) {
+            return new FieldLocation(fieldName, ownerOfField, fieldType);
         }
 
         public String fieldName() {
@@ -184,6 +186,10 @@ public abstract class CodeLocation<T extends CodeLocation<T>> implements Compara
         @Override
         public String prettyPrint() {
             return String.format("[Field: %s at %s(%s.java:1)]", fieldName(), typeName(), typeShortName());
+        }
+
+        public Dotted fieldType() {
+            return fieldType;
         }
 
     }

--- a/src/main/java/org/mutabilitydetector/locations/CodeLocation.java
+++ b/src/main/java/org/mutabilitydetector/locations/CodeLocation.java
@@ -1,5 +1,7 @@
 package org.mutabilitydetector.locations;
 
+import java.util.Objects;
+
 /*
  * #%L
  * MutabilityDetector
@@ -135,6 +137,9 @@ public abstract class CodeLocation<T extends CodeLocation<T>> implements Compara
         private final @Nonnull Dotted fieldType;
 
         private FieldLocation(String fieldName, ClassLocation ownerOfField, Dotted fieldType) {
+            Objects.requireNonNull(fieldName, "fieldName cannot be null");
+            Objects.requireNonNull(ownerOfField, "ownerOfField cannot be null");
+            Objects.requireNonNull(fieldType, "fieldType cannot be null");
             this.fieldName = fieldName;
             this.ownerOfField = ownerOfField;
             this.fieldType = fieldType;

--- a/src/main/java/org/mutabilitydetector/locations/Dotted.java
+++ b/src/main/java/org/mutabilitydetector/locations/Dotted.java
@@ -22,6 +22,8 @@ package org.mutabilitydetector.locations;
 
 
 import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.FieldNode;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -71,6 +73,25 @@ public final class Dotted extends ClassName {
 
     public static Dotted fromType(Type type) {
         return dotted(type.getClassName());
+    }
+
+    /**
+     * @param fieldDescription a field's descriptor (see {@link Type})
+     * @return a lightweight representation of a field's declared type
+     * @see org.objectweb.asm.ClassVisitor#visitField(int, String, String, String, Object)
+     */
+    public static Dotted fromFieldDescription(final String fieldDescription) {
+        final Type type = Type.getType(fieldDescription);
+        final int sort = type.getSort();
+        return sort == Type.ARRAY ? dotted(fieldDescription) : fromType(type);
+    }
+
+    public static Dotted fromFieldNode(final FieldNode node) {
+        return fromFieldDescription(node.desc);
+    }
+
+    public static Dotted fromFieldInsnNode(final FieldInsnNode node) {
+        return fromFieldDescription(node.desc);
     }
 
     public String asResource() {

--- a/src/main/java/org/mutabilitydetector/unittesting/matchers/reasons/ProvidedOtherClass.java
+++ b/src/main/java/org/mutabilitydetector/unittesting/matchers/reasons/ProvidedOtherClass.java
@@ -30,6 +30,8 @@ import static org.mutabilitydetector.MutabilityReason.ABSTRACT_TYPE_TO_FIELD;
 import static org.mutabilitydetector.MutabilityReason.COLLECTION_FIELD_WITH_MUTABLE_ELEMENT_TYPE;
 import static org.mutabilitydetector.MutabilityReason.MUTABLE_TYPE_TO_FIELD;
 
+import java.util.stream.StreamSupport;
+
 import org.hamcrest.Matcher;
 import org.mutabilitydetector.MutableReasonDetail;
 import org.mutabilitydetector.checkers.MutableTypeToFieldChecker;
@@ -289,11 +291,7 @@ public final class ProvidedOtherClass {
             if (reasonDetail.reason().isOneOf(MUTABLE_TYPE_TO_FIELD) && codeLocation instanceof FieldLocation) {
                 final FieldLocation location = (FieldLocation) reasonDetail.codeLocation();
                 final Dotted fieldType = location.fieldType();
-                for (final Dotted allowedClass : classNames) {
-                    if (fieldType.equals(allowedClass)) {
-                        return true;
-                    }
-                }
+                return StreamSupport.stream(classNames.spliterator(), false).anyMatch(fieldType::equals);
             }
             return false;
         }

--- a/src/main/java/org/mutabilitydetector/unittesting/matchers/reasons/ProvidedOtherClass.java
+++ b/src/main/java/org/mutabilitydetector/unittesting/matchers/reasons/ProvidedOtherClass.java
@@ -30,9 +30,6 @@ import static org.mutabilitydetector.MutabilityReason.ABSTRACT_TYPE_TO_FIELD;
 import static org.mutabilitydetector.MutabilityReason.COLLECTION_FIELD_WITH_MUTABLE_ELEMENT_TYPE;
 import static org.mutabilitydetector.MutabilityReason.MUTABLE_TYPE_TO_FIELD;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Type;
-
 import org.hamcrest.Matcher;
 import org.mutabilitydetector.MutableReasonDetail;
 import org.mutabilitydetector.checkers.MutableTypeToFieldChecker;
@@ -291,22 +288,11 @@ public final class ProvidedOtherClass {
             final CodeLocation<?> codeLocation = reasonDetail.codeLocation();
             if (reasonDetail.reason().isOneOf(MUTABLE_TYPE_TO_FIELD) && codeLocation instanceof FieldLocation) {
                 final FieldLocation location = (FieldLocation) reasonDetail.codeLocation();
-                try {
-                    final Class<?> type = Class.forName(location.typeName());
-                    try {
-                        final Field field = type.getDeclaredField(location.fieldName());
-                        final Type fieldType = field.getType();
-                        if (fieldType instanceof Class) {
-                            final Dotted fieldClassDotted = Dotted.fromClass((Class<?>) fieldType);
-                            for (final Dotted allowedClass : classNames) {
-                                if (fieldClassDotted.equals(allowedClass)) {
-                                    return true;
-                                }
-                            }
-                        }
-                    } catch (final NoSuchFieldException | SecurityException e) {
+                final Dotted fieldType = location.fieldType();
+                for (final Dotted allowedClass : classNames) {
+                    if (fieldType.equals(allowedClass)) {
+                        return true;
                     }
-                } catch (final ClassNotFoundException e) {
                 }
             }
             return false;

--- a/src/test/java/org/mutabilitydetector/cli/SessionResultsFormatterTest.java
+++ b/src/test/java/org/mutabilitydetector/cli/SessionResultsFormatterTest.java
@@ -39,7 +39,6 @@ import static org.mutabilitydetector.locations.Slashed.slashed;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 
 import org.junit.Test;
 import org.mutabilitydetector.AnalysisResult;
@@ -48,6 +47,7 @@ import org.mutabilitydetector.IsImmutable;
 import org.mutabilitydetector.MutableReasonDetail;
 import org.mutabilitydetector.cli.CommandLineOptions.ReportMode;
 import org.mutabilitydetector.locations.CodeLocation.FieldLocation;
+import org.mutabilitydetector.locations.Dotted;
 import org.mutabilitydetector.misc.TimingUtil;
 
 public class SessionResultsFormatterTest {
@@ -91,7 +91,8 @@ public class SessionResultsFormatterTest {
                                                                                         CAN_BE_SUBCLASSED),
                                                                 newMutableReasonDetail("2nd checker reason message",
                                                                                         FieldLocation.fieldLocation("myField",
-                                                                                                                    fromInternalName("path/to/OtherClass")),
+                                                                                                                    fromInternalName("path/to/OtherClass"),
+                                                                                                                    Dotted.dotted("java.lang.String")),
                                                                                         MUTABLE_TYPE_TO_FIELD));
 
         BatchAnalysisOptions options = mock(BatchAnalysisOptions.class);

--- a/src/test/java/org/mutabilitydetector/locations/DottedTest.java
+++ b/src/test/java/org/mutabilitydetector/locations/DottedTest.java
@@ -1,0 +1,164 @@
+package org.mutabilitydetector.locations;
+
+/*-
+ * #%L
+ * MutabilityDetector
+ * %%
+ * Copyright (C) 2008 - 2019 Graham Allan
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import static org.junit.Assert.assertEquals;
+import static org.mutabilitydetector.locations.CodeLocation.FieldLocation.fieldLocation;
+
+import java.lang.reflect.Field;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import org.junit.Test;
+import org.mutabilitydetector.TestUtil;
+import org.mutabilitydetector.checkers.AsmMutabilityChecker;
+import org.mutabilitydetector.locations.CodeLocation.ClassLocation;
+import org.mutabilitydetector.locations.CodeLocation.FieldLocation;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+
+public class DottedTest {
+
+    @NotThreadSafe
+    protected static class FieldExtractor extends AsmMutabilityChecker {
+
+        private final Map<? super String, FieldLocation> fields = new HashMap<>();
+
+        @Override
+        public FieldVisitor visitField(final int access, final String name, final String desc, final String signature, final Object value) {
+            fields.put(name,
+                    fieldLocation(name, ClassLocation.fromInternalName(name), Dotted.fromFieldDescription(desc)));
+            return super.visitField(access, name, desc, signature, value);
+        }
+
+        public FieldLocation getFieldLocation(final String fieldName) {
+            return fields.get(fieldName);
+        }
+
+    }
+
+    /**
+     * Verify that simple types extracted by a {@link ClassVisitor} match what would
+     * be obtained by Reflection.
+     */
+    @Test
+    public final void simplePojoFieldTypesExtracted() {
+        // given
+        final FieldExtractor extractor = new FieldExtractor();
+        final Class<?> toAnalyse = Pojo.class;
+
+        // when
+
+        TestUtil.runChecker(extractor, toAnalyse);
+
+        // then
+        assertAsmTypesMatcheReflection(extractor, toAnalyse);
+    }
+
+    /**
+     * A class with simple types only, no generics.
+     */
+    protected static class Pojo {
+        int intField;
+        Function<Integer, Long> functionField;
+        byte[] byteArrayField;
+        Predicate<String> predicateField;
+        String objectField;
+    }
+
+    /**
+     * Verify that parameterised (generic) types extracted by a {@link ClassVisitor}
+     * match what would be obtained by Reflection.
+     */
+    @Test
+    public final void parameterisedFieldTypesExtracted() {
+        // given
+        final FieldExtractor extractor = new FieldExtractor();
+        final Class<?> toAnalyse = GenericPojo.class;
+
+        // when
+
+        TestUtil.runChecker(extractor, toAnalyse);
+
+        // then
+        assertAsmTypesMatcheReflection(extractor, toAnalyse);
+    }
+
+    /**
+     * A class with a generic type parameter.
+     *
+     * @param <T> Some unbounded type parameter
+     */
+    protected static class GenericPojo<T> {
+        T objectField;
+        Function<T, T> functionField;
+        T[] arrayField;
+    }
+
+    /**
+     * Verify that bounded parameterised (generic) types extracted by a
+     * {@link ClassVisitor} match what would be obtained by Reflection.
+     */
+    @Test
+    public final void boundedParameterisedFieldTypesExtracted() {
+        // given
+        final FieldExtractor extractor = new FieldExtractor();
+        final Class<?> toAnalyse = BoundedGenericPojo.class;
+
+        // when
+
+        TestUtil.runChecker(extractor, toAnalyse);
+
+        // then
+        assertAsmTypesMatcheReflection(extractor, toAnalyse);
+    }
+
+    /**
+     * A class with bounded generic type parameters.
+     *
+     * @param <S> some generic type parameter
+     * @param <T> some bounded generic type parameter
+     */
+    protected static class BoundedGenericPojo<S extends Object , T extends List<? extends S>> {
+        T listField;
+        S singleField;
+        Function<? extends S, T> functionField;
+        T arrayField;
+        Predicate<? super S> predicateField;
+    }
+
+    protected void assertAsmTypesMatcheReflection(final FieldExtractor extractor, final Class<?> toAnalyse) {
+        for (final Field field : toAnalyse.getDeclaredFields()) {
+            final Class<?> type = field.getType();
+            final Dotted reflectionDerivedClass = Dotted.fromClass(type);
+            final String fieldName = field.getName();
+            final FieldLocation fieldLocation = extractor.getFieldLocation(fieldName);
+            assertEquals("Unexpected type for field: " + fieldName, reflectionDerivedClass, fieldLocation.fieldType());
+        }
+    }
+
+}

--- a/src/test/java/org/mutabilitydetector/locations/DottedTest.java
+++ b/src/test/java/org/mutabilitydetector/locations/DottedTest.java
@@ -101,7 +101,6 @@ public class DottedTest {
         final Class<?> toAnalyse = GenericPojo.class;
 
         // when
-
         TestUtil.runChecker(extractor, toAnalyse);
 
         // then
@@ -130,7 +129,6 @@ public class DottedTest {
         final Class<?> toAnalyse = BoundedGenericPojo.class;
 
         // when
-
         TestUtil.runChecker(extractor, toAnalyse);
 
         // then
@@ -147,7 +145,7 @@ public class DottedTest {
         T listField;
         S singleField;
         Function<? extends S, T> functionField;
-        T arrayField;
+        T[] arrayField;
         Predicate<? super S> predicateField;
     }
 

--- a/src/test/java/org/mutabilitydetector/locations/FieldLocationTest.java
+++ b/src/test/java/org/mutabilitydetector/locations/FieldLocationTest.java
@@ -38,29 +38,30 @@ public class FieldLocationTest {
     @Test
     public void hasFieldNameAndNameOfTypeContainingField() throws Exception {
         FieldLocation fieldLocation = FieldLocation.fieldLocation("myFieldName",
-                ClassLocation.fromInternalName("a/b/MyClass"));
+                ClassLocation.fromInternalName("a/b/MyClass"), Dotted.dotted("long"));
         assertThat(fieldLocation.fieldName(), is("myFieldName"));
         assertThat(fieldLocation.typeName(), is("a.b.MyClass"));
     }
 
     @Test
     public void comparesToOtherFieldLocationsSortingAlphabeticallyByOwningTypeNameThenFieldName() throws Exception {
-        FieldLocation comparing = fieldLocation("myFieldName", fromInternalName("a/b/MyClass"));
-        assertThat(comparing.compareTo(fieldLocation("myFieldNamd", fromInternalName("a/b/MyClass"))),
+        FieldLocation comparing = fieldLocation("myFieldName", fromInternalName("a/b/MyClass"), Dotted.dotted("int"));
+        assertThat(comparing.compareTo(fieldLocation("myFieldNamd", fromInternalName("a/b/MyClass"), Dotted.dotted("byte"))),
                 is(greaterThan(0)));
-        assertThat(comparing.compareTo(fieldLocation("myFieldName", fromInternalName("a/b/MyClass"))), is(equalTo(0)));
-        assertThat(comparing.compareTo(fieldLocation("myFieldNamf", fromInternalName("a/b/MyClass"))), is(lessThan(0)));
+        assertThat(comparing.compareTo(fieldLocation("myFieldName", fromInternalName("a/b/MyClass"), Dotted.dotted("int"))), is(equalTo(0)));
+        assertThat(comparing.compareTo(fieldLocation("myFieldNamf", fromInternalName("a/b/MyClass"), Dotted.dotted("long"))), is(lessThan(0)));
 
-        assertThat(comparing.compareTo(fieldLocation("myFieldName", fromInternalName("a/b/MyClasr"))),
+        assertThat(comparing.compareTo(fieldLocation("myFieldName", fromInternalName("a/b/MyClasr"), Dotted.dotted("short"))),
                 is(greaterThan(0)));
-        assertThat(comparing.compareTo(fieldLocation("myFieldName", fromInternalName("a/b/MyClass"))), is(equalTo(0)));
-        assertThat(comparing.compareTo(fieldLocation("myFieldName", fromInternalName("a/b/MyClast"))), is(lessThan(0)));
+        assertThat(comparing.compareTo(fieldLocation("myFieldName", fromInternalName("a/b/MyClass"), Dotted.dotted("int"))), is(equalTo(0)));
+        assertThat(comparing.compareTo(fieldLocation("myFieldName", fromInternalName("a/b/MyClast"), Dotted.dotted("float"))), is(lessThan(0)));
     }
 
     @Test
     public void prettyPrintIncludesFieldAndClassName() throws Exception {
         FieldLocation fieldLocation = FieldLocation.fieldLocation("myFieldName",
-                ClassLocation.fromInternalName("a/b/MyClass"));
+                ClassLocation.fromInternalName("a/b/MyClass"), Dotted.dotted("java.util.Map"));
         assertThat(fieldLocation.prettyPrint(), is("[Field: myFieldName at a.b.MyClass(MyClass.java:1)]"));
     }
+
 }

--- a/src/test/java/org/mutabilitydetector/unittesting/AllowedReasonTest.java
+++ b/src/test/java/org/mutabilitydetector/unittesting/AllowedReasonTest.java
@@ -41,6 +41,7 @@ import org.hamcrest.TypeSafeMatcher;
 import org.junit.Test;
 import org.mutabilitydetector.MutableReasonDetail;
 import org.mutabilitydetector.benchmarks.types.InterfaceType;
+import org.mutabilitydetector.locations.Dotted;
 import org.mutabilitydetector.unittesting.matchers.reasons.AllowingNonFinalFields;
 import org.mutabilitydetector.unittesting.matchers.reasons.NoReasonsAllowed;
 
@@ -88,7 +89,7 @@ public class AllowedReasonTest {
     @Test
     public void canAllowArrayFields() throws Exception {
         MutableReasonDetail reason = newMutableReasonDetail("has array field",
-                                                            fieldLocation("myArrayField", fromInternalName("a/b/c")),
+                                                            fieldLocation("myArrayField", fromInternalName("a/b/c"), Dotted.dotted("[B")),
                                                             ARRAY_TYPE_INHERENTLY_MUTABLE);
         
         assertThat(assumingFields("myArrayField").areNotModifiedAndDoNotEscape(),

--- a/src/test/java/org/mutabilitydetector/unittesting/matchers/reasons/AssumeCopiedIntoUnmodifiableTest.java
+++ b/src/test/java/org/mutabilitydetector/unittesting/matchers/reasons/AssumeCopiedIntoUnmodifiableTest.java
@@ -33,7 +33,6 @@ import static org.mutabilitydetector.locations.CodeLocation.FieldLocation.fieldL
 import static org.mutabilitydetector.unittesting.matchers.reasons.AssumeCopiedIntoUnmodifiable.assuming;
 
 import org.junit.Test;
-import org.junit.experimental.theories.DataPoint;
 import org.junit.experimental.theories.DataPoints;
 import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
@@ -45,9 +44,10 @@ import org.mutabilitydetector.locations.CodeLocation.FieldLocation;
 @RunWith(Theories.class)
 public class AssumeCopiedIntoUnmodifiableTest {
     private static final String unusedMessage = "";
-    
-    private static final FieldLocation collectionTypeFieldLocation = fieldLocation("myCollectionField", from(Dotted.dotted("some.Clazz")));
-    
+
+    private static final FieldLocation collectionTypeFieldLocation = fieldLocation("myCollectionField",
+            from(Dotted.dotted("some.Clazz")), Dotted.dotted("java.util.List"));
+
     @DataPoints public static final MutableReasonDetail[] reasons = new MutableReasonDetail[] {
         newMutableReasonDetail(unusedMessage, collectionTypeFieldLocation, ABSTRACT_TYPE_TO_FIELD),
         newMutableReasonDetail(unusedMessage, collectionTypeFieldLocation, ABSTRACT_COLLECTION_TYPE_TO_FIELD),

--- a/src/test/java/org/mutabilitydetector/unittesting/matchers/reasons/ProvidedOtherClassTest.java
+++ b/src/test/java/org/mutabilitydetector/unittesting/matchers/reasons/ProvidedOtherClassTest.java
@@ -33,6 +33,7 @@ import static org.mutabilitydetector.locations.Dotted.dotted;
 import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
+import static org.mutabilitydetector.unittesting.MutabilityMatchers.areNotImmutable;
 
 import org.hamcrest.Matcher;
 import org.junit.Rule;
@@ -148,7 +149,28 @@ public class ProvidedOtherClassTest {
         assertInstancesOf(ClassWithGenericField.class, areImmutable(), provided(SomeInterface.class).isAlsoImmutable());
     }
 
+    /**
+     * When a class is declared as immutable with a type parameter that is
+     * considered immutable, then a field with that type should also be considered
+     * immutable.
+     *
+     * @see {@link https://github.com/MutabilityDetector/MutabilityDetector/issues/104}
+     */
+    @Test
+    public final void considerProvidedImmutableOtherClassesForGenericFields() {
+        assertInstancesOf(ClassWithGenericField.class, areImmutable(),
+                provided(UnrelatedInterface.class, SomeInterface.class).areAlsoImmutable());
+    }
+
+    @Test
+    public final void considerClassWithGenericParameterMutable() {
+        assertInstancesOf(ClassWithGenericField.class, areNotImmutable());
+    }
+
     protected static interface SomeInterface {
+    }
+
+    protected static interface UnrelatedInterface {
     }
 
     protected static final class ClassWithGenericField<T extends SomeInterface> {


### PR DESCRIPTION
This adds a field in `FieldLocation` to capture its type. Downstream
`MutableReasonDetail` Matchers can leverage that to decide whether or
not a violation is valid.

This is an optimisation to PR #144 which uses Reflection to accomplish
the same thing.

Addresses: #104