### PR TITLE
Add support for Java 16 and higher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [ '8', '11', '13', '14', 16 ]
+        java: [ '8', '11', '17' ]
         os: [ 'ubuntu-latest' ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,16 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [ '8', '11', '13', '14' ]
+        java: [ '8', '11', '13', '14', 16 ]
         os: [ 'ubuntu-latest' ]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.java }}
+        distribution: 'zulu'
     - name: print Java version
       run: java -version
     - uses: actions/cache@v2

--- a/pom.xml
+++ b/pom.xml
@@ -399,13 +399,13 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>8.0.1</version>
+      <version>9.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-commons</artifactId>
-      <version>8.0.1</version>
+      <version>9.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -440,7 +440,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.3.3</version>
+      <version>3.10.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This upgrades the ASM and ByteBuddy (via Mockito) dependencies so they are compatible with Java 16 and higher. To test, I built this library with the three current (as of 2 October 2021) LTS Java versions (8, 11, and 17) as well as Java 16. In addition, I tested by running the `ClientOfMutabilityDetector` tests with Java 16 and 17 while pointing to a local version of `MutabilityDetector` built with Java 8.

I also updated the build matrix for GitHub Actions to use only the current LTS versions. While doing so, I upgraded to version 2 of the Action and specified `zulu` as the distribution for consistency with previous builds. I can revert these changes or use `temurin` if necessary.

Resolves: #181