### PR TITLE
Support mutability checks for records

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -403,13 +403,13 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>9.1</version>
+      <version>9.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-commons</artifactId>
-      <version>9.1</version>
+      <version>9.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -427,7 +427,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>31.0.1-jre</version>
+      <version>31.1-jre</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -444,7 +444,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>4.2.0</version>
+      <version>4.6.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/mutabilitydetector/asmoverride/AsmCompatibility.java
+++ b/src/main/java/org/mutabilitydetector/asmoverride/AsmCompatibility.java
@@ -23,5 +23,5 @@ package org.mutabilitydetector.asmoverride;
 import org.objectweb.asm.Opcodes;
 
 public final class AsmCompatibility {
-    public static final int AsmApiVersion = Opcodes.ASM7;
+    public static final int AsmApiVersion = Opcodes.ASM8;
 }

--- a/src/main/java/org/mutabilitydetector/checkers/ImmutableCollectionChecker.java
+++ b/src/main/java/org/mutabilitydetector/checkers/ImmutableCollectionChecker.java
@@ -21,9 +21,7 @@ package org.mutabilitydetector.checkers;
  */
 
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.*;
 import org.mutabilitydetector.checkers.hint.WrappingHint;
 import org.mutabilitydetector.checkers.hint.WrappingHintGenerator;
 import org.mutabilitydetector.checkers.info.CopyMethod;
@@ -54,18 +52,24 @@ public class ImmutableCollectionChecker {
 
         public final String UNMODIFIABLE_METHOD_OWNER = "java.util.Collections";
 
-        public final ImmutableMap<String, String> FIELD_TYPE_TO_IMMUTABLE_METHOD = ImmutableMap.<String, String>builder()
+        public final ImmutableSetMultimap<String, String> FIELD_TYPE_TO_IMMUTABLE_METHOD = ImmutableSetMultimap.<String, String>builder()
                 .put("java.util.Set", "of")
+                .put("java.util.Set", "copyOf")
                 .put("java.util.List", "of")
+                .put("java.util.List", "copyOf")
                 .put("java.util.Map", "of")
+                .put("java.util.Map", "copyOf")
                 .build();
 
-        public final ImmutableMap<String, String> FIELD_TYPE_TO_UNMODIFIABLE_METHOD = ImmutableMap.<String, String>builder()
+        public final ImmutableListMultimap<String, String> FIELD_TYPE_TO_UNMODIFIABLE_METHOD = ImmutableListMultimap.<String, String>builder()
                 .put("java.util.Collection", "unmodifiableCollection")
                 .put("java.util.Set", "unmodifiableSet")
+                .put("java.util.Set", "copyOf")
                 .put("java.util.SortedSet", "unmodifiableSortedSet")
                 .put("java.util.List", "unmodifiableList")
+                .put("java.util.List", "copyOf")
                 .put("java.util.Map", "unmodifiableMap")
+                .put("java.util.Map", "copyOf")
                 .put("java.util.SortedMap", "unmodifiableSortedMap")
                 .build();
 
@@ -191,7 +195,7 @@ public class ImmutableCollectionChecker {
     public boolean checkInvokesImmutableInterfaceMethod() {
         return getLastMethodInsnNode().map(previousInvocation ->
                         Configuration.INSTANCE.FIELD_TYPE_TO_IMMUTABLE_METHOD.containsKey(CLASS_NAME_CONVERTER.dotted(previousInvocation.owner)) &&
-                        Configuration.INSTANCE.FIELD_TYPE_TO_IMMUTABLE_METHOD.get(typeAssignedToField()).equals(previousInvocation.name))
+                        Configuration.INSTANCE.FIELD_TYPE_TO_IMMUTABLE_METHOD.get(typeAssignedToField()).contains(previousInvocation.name))
                     .orElse(false);
 
     }
@@ -199,7 +203,7 @@ public class ImmutableCollectionChecker {
     private boolean wrapsInUnmodifiable() {
         return getLastMethodInsnNode().map(previousInvocation ->
                         Configuration.INSTANCE.UNMODIFIABLE_METHOD_OWNER.equals(CLASS_NAME_CONVERTER.dotted(previousInvocation.owner)) &&
-                        Configuration.INSTANCE.FIELD_TYPE_TO_UNMODIFIABLE_METHOD.get(typeAssignedToField()).equals(previousInvocation.name))
+                        Configuration.INSTANCE.FIELD_TYPE_TO_UNMODIFIABLE_METHOD.get(typeAssignedToField()).contains(previousInvocation.name))
                     .orElse(false);
     }
 

--- a/src/main/java/org/mutabilitydetector/checkers/hint/WrappingHintGenerator.java
+++ b/src/main/java/org/mutabilitydetector/checkers/hint/WrappingHintGenerator.java
@@ -96,7 +96,7 @@ public final class WrappingHintGenerator {
      */
     private void generateWrappingPart(WrappingHint.Builder builder) {
         builder.setWrappingMethodOwnerName(configuration.UNMODIFIABLE_METHOD_OWNER)
-                .setWrappingMethodName(configuration.FIELD_TYPE_TO_UNMODIFIABLE_METHOD.get(typeAssignedToField));
+                .setWrappingMethodName(configuration.FIELD_TYPE_TO_UNMODIFIABLE_METHOD.get(typeAssignedToField).iterator().next());
     }
 
     private static String formatTypeParameter(String typeParameter) {


### PR DESCRIPTION
This ensures that Java record classes can be checked for mutability. In addition, it adds support for use with JDK18.

Resolves #186