### PR TITLE
Removed 4 unnecessary stubbings in MutableTypeToFieldCheckerTest.java

### DIFF
--- a/src/test/java/org/mutabilitydetector/benchmarks/mutabletofield/MutableTypeToFieldCheckerTest.java
+++ b/src/test/java/org/mutabilitydetector/benchmarks/mutabletofield/MutableTypeToFieldCheckerTest.java
@@ -125,7 +125,6 @@ public class MutableTypeToFieldCheckerTest {
     public void requestsMutableStatusOfPublishedField() throws Exception {
         AnalysisInProgress analysisInProgressWhenRequestingMutabilityOfField = analysisInProgressIncludes(MutableByHavingMutableFieldAssigned.class);
 
-        when(session.getResults()).thenReturn(Collections.<AnalysisResult>emptyList());
         when(session.processTransitiveAnalysis(
                 mutableExample,
                 analysisInProgressWhenRequestingMutabilityOfField))
@@ -150,7 +149,6 @@ public class MutableTypeToFieldCheckerTest {
                 NOT_IMMUTABLE,
                 newMutableReasonDetail(unusedMessage, unusedCodeLocation(), ABSTRACT_COLLECTION_TYPE_TO_FIELD));
 
-        when(session.getResults()).thenReturn(Collections.<AnalysisResult>emptyList());
         when(session.processTransitiveAnalysis(mutableExample, analysisInProgressWhenRequestingMutabilityOfField)).thenReturn(mutableResult);
 
         result = runChecker(checkerWithMockedSession, MutableByHavingMutableFieldAssigned.class);
@@ -163,7 +161,6 @@ public class MutableTypeToFieldCheckerTest {
     public void failsCheckIfAnyFieldsHaveMutableAssignedToThem() throws Exception {
         AnalysisInProgress analysisInProgressWhenRequestingMutabilityOfField = analysisInProgressIncludes(MutableByHavingMutableFieldAssigned.class);
 
-        when(session.getResults()).thenReturn(Collections.<AnalysisResult>emptyList());
         when(session.processTransitiveAnalysis(mutableExample, analysisInProgressWhenRequestingMutabilityOfField)).thenReturn(unusedAnalysisResult);
 
         result = runChecker(checkerWithMockedSession, MutableByHavingMutableFieldAssigned.class);
@@ -193,7 +190,6 @@ public class MutableTypeToFieldCheckerTest {
 
     @Test
     public void codeLocationIsFieldLocation() throws Exception {
-        when(session.getResults()).thenReturn(Collections.<AnalysisResult>emptyList());
         when(session.processTransitiveAnalysis(eq(mutableExample), any(AnalysisInProgress.class))).thenReturn(unusedAnalysisResult);
 
         runChecker(checkerWithMockedSession, MutableByHavingMutableFieldAssigned.class);


### PR DESCRIPTION
In our analysis of the project, we observed that 
1. 1 stubbing is created but never executed in the test `MutableTypeToFieldCheckerTest.equestsMutableStatusOfPublishedField`,
2. 1 stubbing is created but never executed in the test `MutableTypeToFieldCheckerTest.failsCheckWhenMutableTypeIsAssignedToField`,
3. 1 stubbing is created but never executed in the test `MutableTypeToFieldCheckerTest.failsCheckIfAnyFieldsHaveMutableAssignedToThem`,
4. 1 stubbing is created but never executed in the test `MutableTypeToFieldCheckerTest.codeLocationIsFieldLocation`,

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html).

We propose below a solution to remove the unnecessary stubbing.