### PR TITLE
Removed 1 unnecessary stubbing in WithAllowedReasonsMatcherTest.java

### DIFF
--- a/src/test/java/org/mutabilitydetector/unittesting/matchers/reasons/WithAllowedReasonsMatcherTest.java
+++ b/src/test/java/org/mutabilitydetector/unittesting/matchers/reasons/WithAllowedReasonsMatcherTest.java
@@ -157,8 +157,6 @@ public class WithAllowedReasonsMatcherTest {
         MutableReasonDetail disallowedReason = newMutableReasonDetail("disallowed", unusedCodeLocation, unusedReason());
         
         Matcher<MutableReasonDetail> onlyAllowOneReason = mock(Matcher.class);
-        when(onlyAllowOneReason.matches(disallowedReason)).thenReturn(false);
-        
         IsImmutableMatcher isImmutable = IsImmutableMatcher.hasIsImmutableStatusOf(IMMUTABLE);
         AnalysisResult analysisResult = analysisResult("some class", NOT_IMMUTABLE, disallowedReason);
         


### PR DESCRIPTION
In our analysis of the project, we observed that 
1. 1 stubbing is created but never executed in the test `WithAllowedReasonsMatcherTest.mismatchDescriptionExplicitlyStatesNoReasonsHaveBeenAllowed` 

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html).

We propose below a solution to remove the unnecessary stubbing.